### PR TITLE
Better handling of UTF-8 paths

### DIFF
--- a/bcr.cc
+++ b/bcr.cc
@@ -192,7 +192,7 @@ bcr_init_radius(void)
 static void
 bcr_rd_init(const QString& fname)
 {
-  ini = inifile_init(qPrintable(fname), MYNAME);
+  ini = inifile_init(fname, MYNAME);
   if (ini->unicode) {
     cet_convert_init(CET_CHARSET_UTF8, 1);
   }

--- a/defs.h
+++ b/defs.h
@@ -944,6 +944,9 @@ void debug_mem_close();
 
 FILE* xfopen(const char* fname, const char* type, const char* errtxt);
 
+// Thin wrapper around fopen() that supports UTF-8 fname on all platforms.
+FILE* ufopen(const char* fname, const char* mode);
+
 // FIXME: case_ignore_strcmp() and case_ignore_strncmp() should probably
 // just be replaced at the call sites.  These shims are just here to make
 // them more accomidating of QString input.

--- a/exif.cc
+++ b/exif.cc
@@ -1408,7 +1408,7 @@ exif_wr_deinit(void)
 {
 
   exif_release_apps();
-  QString tmpname = QString::fromLocal8Bit(fout->name);
+  QString tmpname = QString(fout->name);
   gbfclose(fout);
 
   if (exif_success) {

--- a/explorist_ini.cc
+++ b/explorist_ini.cc
@@ -19,7 +19,7 @@ explorist_ini_try(const char* path)
   char* s;
 
   xasprintf(&inipath, "%s/%s", path, "APP/Atlas.ini");
-  inifile = inifile_init(inipath, myname);
+  inifile = inifile_init(QString::fromUtf8(inipath), myname);
   if (!inifile) {
     xfree(inipath);
     return NULL;

--- a/garmin_device_xml.cc
+++ b/garmin_device_xml.cc
@@ -127,7 +127,7 @@ const gdx_info*
 gdx_read(const char* fname)
 {
   // Test file open-able before gb_open gets a chance to fatal().
-  FILE* fin = fopen(fname, "r");
+  FILE* fin = ufopen(fname, "r");
 
   if (fin) {
     fclose(fin);

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -538,8 +538,7 @@ gbfopen(const QString filename, const char* mode, const char* module)
     file->fileungetc = memapi_ungetc;
     file->filewrite = memapi_write;
   } else {
-    /* Be careful to convert back to local8Bit for these c based APIS */
-    file->name = xstrdup(qPrintable(filename));
+    file->name = qstrdup(filename.toUtf8());
     file->is_pipe = (filename == "-");
 
     /* Do we have a '.gz' extension in the filename ? */

--- a/gbfile.cc
+++ b/gbfile.cc
@@ -538,7 +538,7 @@ gbfopen(const QString filename, const char* mode, const char* module)
     file->fileungetc = memapi_ungetc;
     file->filewrite = memapi_write;
   } else {
-    file->name = qstrdup(filename.toUtf8());
+    file->name = xstrdup(filename);
     file->is_pipe = (filename == "-");
 
     /* Do we have a '.gz' extension in the filename ? */

--- a/ggv_ovl.cc
+++ b/ggv_ovl.cc
@@ -82,7 +82,7 @@ static OVL_COLOR_TYP color;
 static void
 ggv_ovl_rd_init(const QString& fname)
 {
-  inifile = inifile_init(qPrintable(fname), MYNAME);
+  inifile = inifile_init(fname, MYNAME);
   if (inifile->unicode) {
     cet_convert_init(CET_CHARSET_UTF8, 1);
   }

--- a/inifile.cc
+++ b/inifile.cc
@@ -75,7 +75,7 @@ find_gpsbabel_inifile(const char* path)		/* can be empty or NULL */
 #endif
   }
   strcat(buff, GPSBABEL_INIFILE);
-  test = fopen(buff, "rb");
+  test = ufopen(buff, "rb");
   if (test) {
     fclose(test);
     return buff;
@@ -95,7 +95,7 @@ open_gpsbabel_inifile(void)
   if (envstr != NULL) {
     FILE* test;
 
-    test = fopen(envstr, "r");
+    test = ufopen(envstr, "r");
     if (test != NULL) {
       fclose(test);
       return gbfopen(envstr, "r", "GPSBabel");
@@ -247,12 +247,12 @@ inifile_find_value(const inifile_t* inifile, const char* sec_name, const char* k
 	  filename == NULL: try to open global gpsbabel.ini
  */
 inifile_t*
-inifile_init(const char* filename, const char* myname)
+inifile_init(const QString& filename, const char* myname)
 {
   inifile_t* result;
   gbfile* fin = NULL;
 
-  if (filename == NULL) {
+  if (filename.isEmpty()) {
     fin = open_gpsbabel_inifile();
     if (fin == NULL) {
       return NULL;

--- a/inifile.h
+++ b/inifile.h
@@ -34,7 +34,7 @@ typedef struct inifile_s {
 	  reads inifile filename into memory
 	  myname represents the calling module
  */
-inifile_t* inifile_init(const char* filename, const char* myname);
+inifile_t* inifile_init(const QString& filename, const char* myname);
 void inifile_done(inifile_t* inifile);
 
 int inifile_has_section(const inifile_t* inifile, const char* section);

--- a/kml.cc
+++ b/kml.cc
@@ -550,7 +550,8 @@ kml_wr_deinit(void)
 
   if (!posnfilenametmp.isEmpty()) {
 #if __WIN32__
-    MoveFileExA(qPrintable(posnfilenametmp), qPrintable(posnfilename),
+    MoveFileExW((const wchar_t*) posnfilenametmp.utf16(),
+                (const wchar_t*) posnfilename.utf16(),
                 MOVEFILE_REPLACE_EXISTING);
 #endif
     QFile::rename(posnfilenametmp, posnfilename);

--- a/main.cc
+++ b/main.cc
@@ -303,7 +303,7 @@ main(int argc, char* argv[])
 #endif
 
   if (gpsbabel_time != 0) {	/* within testo ? */
-    global_opts.inifile = inifile_init(NULL, MYNAME);
+    global_opts.inifile = inifile_init(QString(), MYNAME);
   }
 
   init_vecs();
@@ -592,7 +592,7 @@ main(int argc, char* argv[])
       if (!optarg || strcmp(optarg, "") == 0) {	/* from GUI to preserve inconsistent options */
         global_opts.inifile = NULL;
       } else {
-        global_opts.inifile = inifile_init(optarg, MYNAME);
+        global_opts.inifile = inifile_init(QString::fromUtf8(optarg), MYNAME);
       }
       break;
     case 'b':

--- a/mtk_logger.cc
+++ b/mtk_logger.cc
@@ -561,9 +561,9 @@ static void mtk_read(void)
 
   log_enabled = 0;
   init_scan = 0;
-  dout = fopen(TEMP_DATA_BIN, "r+b");
+  dout = ufopen(TEMP_DATA_BIN, "r+b");
   if (dout == NULL) {
-    dout = fopen(TEMP_DATA_BIN, "wb");
+    dout = ufopen(TEMP_DATA_BIN, "wb");
     if (dout == NULL) {
       fatal(MYNAME ": Can't create temporary file %s", TEMP_DATA_BIN);
       return;
@@ -617,7 +617,7 @@ static void mtk_read(void)
     dsize = 0;
     init_scan = 0;
     rename(TEMP_DATA_BIN, TEMP_DATA_BIN_OLD);
-    dout = fopen(TEMP_DATA_BIN, "wb");
+    dout = ufopen(TEMP_DATA_BIN, "wb");
     if (dout == NULL) {
       fatal(MYNAME ": Can't create temporary file %s", TEMP_DATA_BIN);
       return;
@@ -943,7 +943,7 @@ static void mtk_csv_init(char* csv_fname, unsigned long bitmask)
   dbg(1, "Opening csv output file %s...\n", csv_fname);
 
   // can't use gbfopen here - it will fatal() if file doesn't exist
-  if ((cf = fopen(csv_fname, "r")) != NULL) {
+  if ((cf = ufopen(csv_fname, "r")) != NULL) {
     fclose(cf);
     warning(MYNAME ": CSV file %s already exist ! Cowardly refusing to overwrite.\n", csv_fname);
     return;
@@ -1476,7 +1476,7 @@ static void file_init_m241(const QString& fname)
 static void file_init(const QString& fname)
 {
   dbg(4, "Opening file %s...\n", qPrintable(fname));
-  if (fl = fopen(qPrintable(fname), "rb"), NULL == fl) {
+  if (fl = ufopen(fname.toUtf8(), "rb"), NULL == fl) {
     fatal(MYNAME ": Can't open file '%s'\n", qPrintable(fname));
   }
   switch (mtk_device) {

--- a/raymarine.cc
+++ b/raymarine.cc
@@ -169,7 +169,7 @@ find_symbol_num(const QString& descr)
 static void
 raymarine_rd_init(const QString& fname)
 {
-  fin = inifile_init(qPrintable(fname), MYNAME);
+  fin = inifile_init(fname, MYNAME);
   if (fin->unicode) {
     cet_convert_init(CET_CHARSET_UTF8, 1);
   }

--- a/shape.cc
+++ b/shape.cc
@@ -56,12 +56,12 @@ arglist_t shp_args[] = {
 static void
 my_rd_init(const QString& fname)
 {
-  ihandle = SHPOpen(qPrintable(fname), "rb");
+  ihandle = SHPOpen(fname.toUtf8(), "rb");
   if (ihandle == NULL) {
     fatal(MYNAME ":Cannot open shp file %s for reading\n", qPrintable(fname));
   }
 
-  ihandledb = DBFOpen(qPrintable(fname), "rb");
+  ihandledb = DBFOpen(fname.toUtf8(), "rb");
   if (ihandledb == NULL) {
     fatal(MYNAME ":Cannot open dbf file %s for reading\n", qPrintable(fname));
   }
@@ -317,7 +317,7 @@ my_write(void)
   switch (global_opts.objective) {
   case wptdata:
   case unknown_gpsdata:
-    ohandle = SHPCreate(qPrintable(ofname), SHPT_POINT);
+    ohandle = SHPCreate(ofname.toUtf8(), SHPT_POINT);
 
     if (ohandle == NULL) {
       fatal(MYNAME ":Cannot open %s for writing\n",
@@ -326,7 +326,7 @@ my_write(void)
     waypt_disp_all(my_write_wpt);
     break;
   case trkdata:
-    ohandle = SHPCreate(qPrintable(ofname), SHPT_ARC);
+    ohandle = SHPCreate(ofname.toUtf8(), SHPT_ARC);
 
     if (ohandle == NULL) {
       fatal(MYNAME ":Cannot open %s for writing\n",

--- a/v900.cc
+++ b/v900.cc
@@ -166,7 +166,7 @@ v900_rd_init(const QString& fname)
      that will be translated to a single \n, making the line len one character shorter than
      on linux machines.
    */
-  fin = fopen(qPrintable(fname),"rb");
+  fin = ufopen(fname.toUtf8(), "rb");
   if (!fin) {
     fatal("v900: could not open '%s'.\n", qPrintable(fname));
   }

--- a/wbt-200.cc
+++ b/wbt-200.cc
@@ -430,7 +430,7 @@ static int rd_buf(void* buf, int len)
 static void file_init(const QString& fname)
 {
   db(1, "Opening file...\n");
-  if ((fl = fopen(qPrintable(fname), "rb")) == NULL) {
+  if ((fl = ufopen(fname.toUtf8(), "rb")) == NULL) {
     fatal(MYNAME ": Can't open file '%s'\n", qPrintable(fname));
   }
 }


### PR DESCRIPTION
Remove gpsbabel calls to qPrintable which destroys non-ANSI path names on Windows. Replace with QString::toUtf8() and modify low-level file handling code to use _wfopen() and other wide-char functions on Windows to support non-ASCII paths. (I did an experiment to convince myself that fopen() doesn't do UTF-8, and that _wfopen() correctly creates a file with a non-ASCII filename starting from a UTF-8 name.) Add ufopen() function as a UTF-8 wrapper for fopen(). Change inifile_init() filename argument type to QString.

Leave serial port paths alone ("if your serial port path has non-ANSI characters, you're going to have a bad time").