### PR TITLE
Correctly encode output paths in native locale on non-Windows

### DIFF
--- a/util.cc
+++ b/util.cc
@@ -270,8 +270,8 @@ ufopen(const char* fname, const char* mode)
   return _wfopen((const wchar_t*) QString(fname).utf16(),
                  (const wchar_t*) QString(mode).utf16());
 #else
-  // On other platforms, UTF-8 Just Works (TM).
-  return fopen(fname, mode);
+  // On other platforms, convert to native locale (UTF-8 or other 8-bit).
+  return fopen(qPrintable(QString(fname)), mode);
 #endif
 }
 


### PR DESCRIPTION
On Mac/Linux, convert output file path from internal UTF-8 to local encoding (which may be UTF-8 or something else) when creating the file. Fixes test_encoding failure.